### PR TITLE
Use hard links for deployed pack_icon files

### DIFF
--- a/.build/copy-pack_icon.js
+++ b/.build/copy-pack_icon.js
@@ -3,6 +3,25 @@ import fs from "fs";
 import fse from "fs-extra";
 import { getSafeFolderName } from "./path-utils.js";
 
+function replaceFileWithHardLink(srcPath, dstPath) {
+    if (fs.existsSync(dstPath)) {
+        fs.rmSync(dstPath, { force: true });
+    }
+
+    fse.ensureDirSync(path.dirname(dstPath));
+
+    try {
+        fs.linkSync(srcPath, dstPath);
+    } catch (err) {
+        const code = err?.code;
+        if (code === "EXDEV" || code === "EPERM" || code === "EACCES") {
+            fse.copyFileSync(srcPath, dstPath);
+            return;
+        }
+        throw err;
+    }
+}
+
 export function writePackIcon(rootDir, properties) {
     const srcIcon = path.join(rootDir, "pack_icon.png");
 
@@ -14,13 +33,13 @@ export function writePackIcon(rootDir, properties) {
     const bpIcon = path.join(bpDir, "pack_icon.png");
 
     fse.ensureDirSync(bpDir);
-    fse.copyFileSync(srcIcon, bpIcon);
+    replaceFileWithHardLink(srcIcon, bpIcon);
 
     const rpDir = path.join(rootDir, "RP");
     const rpIcon = path.join(rpDir, "pack_icon.png");
 
     fse.ensureDirSync(rpDir);
-    fse.copyFileSync(srcIcon, rpIcon);
+    replaceFileWithHardLink(srcIcon, rpIcon);
 
     if (properties?.id) {
         const safeFolderName = getSafeFolderName(properties.id, "addon id");
@@ -28,6 +47,6 @@ export function writePackIcon(rootDir, properties) {
         const rpTexturesIcon = path.join(rpDir, "textures", safeFolderName, "pack_icon.png");
 
         fse.ensureDirSync(path.dirname(rpTexturesIcon));
-        fse.copyFileSync(srcIcon, rpTexturesIcon);
+        replaceFileWithHardLink(srcIcon, rpTexturesIcon);
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid duplicating `pack_icon.png` bytes when deploying BP/RP outputs on the same volume; Windows junctions are directory-only so a file-level link is needed.

### Description
- Add `replaceFileWithHardLink(srcPath, dstPath)` which tries `fs.linkSync` and falls back to `fse.copyFileSync` on `EXDEV`/`EPERM`/`EACCES`, and replace the `fse.copyFileSync` calls in `.build/copy-pack_icon.js` with this helper for BP, RP, and `RP/textures/<addon id>/pack_icon.png`.

### Testing
- Ran `node --check .build/copy-pack_icon.js` which succeeded; ran `pnpm -s typecheck` which failed due to unrelated syntax errors in `src/properties.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e28c20548333aff889650503ab79)